### PR TITLE
Use Mono compatible Xml Document Transformation library.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "xdt"]
 	path = xdt
-	url = https://git01.codeplex.com/xdt
+	url = https://github.com/mrward/xdt.git


### PR DESCRIPTION
Change xdt submodule to point to https://github.com/mrward/xdt.git which has a patched version of Microsoft's Xml Document Transformation library that works with Mono.

This is a change so the Linux builds of MonoDevelop uses the correct XDT library that is compatible with Mono.

Ideally we should create a mono/xdt repository.

I do not have permission to update mono/nuget directly.
